### PR TITLE
Add ZenithWave Capital experience and update Radical AI end date

### DIFF
--- a/client/src/content.jsx
+++ b/client/src/content.jsx
@@ -68,9 +68,20 @@ const content = {
   experience: {
     work: [
       {
+        title: "Founding Software Engineer",
+        company: "ZenithWave Capital, London, England, United Kingdom",
+        period: "February 2025 – July 2025",
+        description: [
+          "Founding team member at a financial technology startup focused on innovative capital solutions.",
+          "Architected and developed core platform infrastructure from the ground up.",
+          "Collaborated with stakeholders to define technical vision and product roadmap.",
+          "Led engineering decisions and technology stack selection for scalable financial applications.",
+        ],
+      },
+      {
         title: "Full Stack Developer Intern",
         company: "Radical AI, London, UK",
-        period: "May 2024 – Present",
+        period: "May 2024 – Dec 2024",
         description: [
           "Designed a modular on-boarding Welcome Screen with React.js and MUI, driving a 25% increase in user engagement.",
           "Enhanced application responsiveness by 35% using custom React hooks for efficient state management.",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "code",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
## Purpose
Update professional experience section to reflect the user's latest career progression, adding their new founding engineer role at ZenithWave Capital and properly ending their previous internship at Radical AI in December 2024.

## Code changes
- **Added new work experience entry**: ZenithWave Capital position as Founding Software Engineer (February 2025 - July 2025) with comprehensive role description including platform architecture, stakeholder collaboration, and technical leadership responsibilities
- **Updated existing experience**: Changed Radical AI internship period from "May 2024 – Present" to "May 2024 – Dec 2024" to reflect the actual end date
- **Added package-lock.json**: New lockfile generated for dependency management

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/a12f5c23c8624889b8fb86612a3afe88/aura-oasis)

👀 [Preview Link](https://a12f5c23c8624889b8fb86612a3afe88-aura-oasis.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>a12f5c23c8624889b8fb86612a3afe88</projectId>-->
<!--<branchName>aura-oasis</branchName>-->